### PR TITLE
remove AAVE incoming amount validation

### DIFF
--- a/contracts/multiply/MultiplyProxyActions.sol
+++ b/contracts/multiply/MultiplyProxyActions.sol
@@ -802,7 +802,6 @@ contract MultiplyProxyActions {
       "requested and received amounts mismatch"
     );
 
-
     if (mode == 0) {
       _decreaseMP(exchangeData, cdpData, addressRegistry, premiums[0]);
     }


### PR DESCRIPTION
As for comment on discord

 Oazo decided to add this check in the code contrary to e.g. changing the documentation.
The current check enforces a strict equality which does not hold if the contract had any initial non-zero token balance of this
token. 


Update in documentation is required