### PR TITLE
fix for different than 18 decimals

### DIFF
--- a/contracts/multiply/MultiplyProxyActions.sol
+++ b/contracts/multiply/MultiplyProxyActions.sol
@@ -649,8 +649,7 @@ contract MultiplyProxyActions {
     uint256 daiLeft = IERC20(DAI).balanceOf(address(this));
 
     require(cdpData.requiredDebt <= daiLeft, "cannot repay all debt");
-    cdpData.withdrawCollateral = convertTo18(cdpData.gemJoin, cdpData.withdrawCollateral);
-
+    
     wipeAndFreeGem(
       addressRegistry.manager,
       cdpData.gemJoin,


### PR DESCRIPTION
Fix for bug finded by chainSecurity

There is an additional problem we haven't reported so far in _closeWithdrawCollateralSkipFL for collaterals with non 18 decimals:
wipeAndFreeGem() expects the collateral amount in the unit of the collateral token and converts it to the 18 decimals representation.
However in _closeWithdrawCollateralSkipFL this is already done before calling wipeAndFreeGem():
cdpData.withdrawCollateral = convertTo18(cdpData.gemJoin, cdpData.withdrawCollateral);

wipeAndFreeGem(
  addressRegistry.manager,
  cdpData.gemJoin,
  cdpData.cdpId,
  cdpData.requiredDebt,
  cdpData.withdrawCollateral
);
For collaterals with 18 decimals this has no effect however for tokens without 18 decimals the amount will be converted twice,
resulting in an incorrect amount.

We strongly recommend to have tests for all possible scenarios with collaterals having non 18 decimals, e.g. WBTC in addition to
tokens with 18 decimals.