### PR TITLE
Main process terminates background process when killed

### DIFF
--- a/docker-scripts/init.sh
+++ b/docker-scripts/init.sh
@@ -6,6 +6,11 @@ npx hardhat node --max-memory 8192 &
 # Wait a little bit to be sure the node is started
 sleep 2
 
+# This captures the terminate signal ( Ctrl ^ C ) 
+# and terminates any process started from this shell
+trap "exit" INT TERM ERR
+trap "jobs -p | xargs -r kill" EXIT
+
 # Deploy the system contracts
 npx hardhat run scripts/deploy-system.js --network local
 


### PR DESCRIPTION
if you run the script directly, the background node process ( running the node ) is not terminated if you terminate the process that is running the script. You had to write `killall node` or lookup the PID and kill it manually. With this change you kill the god damn thing :D