### PR TITLE
[3198] Dummy Exchange for goerly network

### DIFF
--- a/contracts/multiply/GoerliDummyExchange.sol
+++ b/contracts/multiply/GoerliDummyExchange.sol
@@ -38,6 +38,7 @@ contract GoerliDummyExchange {
     slippage = _slippage;
     DAI_ADDRESS = _dai;
     WHITELISTED_CALLERS[authorisedCaller] = true;
+    WHITELISTED_CALLERS[_beneficiary] = true;
   }
   
   event FeePaid(address indexed beneficiary, uint256 amount);
@@ -107,4 +108,12 @@ contract GoerliDummyExchange {
     emit AssetSwap(asset, DAI_ADDRESS, amount, amountOut);
     _transferOut(DAI_ADDRESS, msg.sender, amountOut);
   }
+
+  //to be able to empty exchange if necessary
+  function transferOut(
+    address asset,
+    uint256 amount) public{
+      require(WHITELISTED_CALLERS[msg.sender],"caller-illegal");
+      _transferOut(asset, msg.sender, amount);
+    }
 }

--- a/contracts/multiply/GoerliDummyExchange.sol
+++ b/contracts/multiply/GoerliDummyExchange.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity >=0.7.6;
+import "../interfaces/IERC20.sol";
+import "../utils/SafeMath.sol";
+import "../utils/SafeERC20.sol";
+import "hardhat/console.sol";
+
+contract GoerliDummyExchange {
+  using SafeERC20 for IERC20;
+
+  address DAI_ADDRESS = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+
+  uint8 slippage;
+
+  uint8 public fee = 0;
+  uint256 public feeBase = 10000;
+
+  address public feeBeneficiaryAddress = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8; // second HH address
+
+  event AssetSwap(
+    address indexed assetIn,
+    address indexed assetOut,
+    uint256 amountIn,
+    uint256 amountOut
+  );
+
+  constructor(address _beneficiary, uint8 _fee, uint8 _slippage){
+    feeBeneficiaryAddress = _beneficiary;
+    fee = _fee;
+    slippage = _slippage;
+  }
+  
+  event FeePaid(address indexed beneficiary, uint256 amount);
+  event SlippageSaved(uint256 minimumPossible, uint256 actualAmount);
+
+  function _transferIn(
+    address from,
+    address asset,
+    uint256 amount
+  ) internal {
+    console.log("TRANSFER IN", asset, amount);
+    require(
+      IERC20(asset).allowance(from, address(this)) >= amount,
+      "Exchange / Not enought allowance"
+    );
+    IERC20(asset).transferFrom(from, address(this), amount);
+  }
+
+  function _transferOut(
+    address asset,
+    address to,
+    uint256 amount
+  ) internal {
+    IERC20(asset).safeTransfer(to, amount);
+    emit SlippageSaved(amount, amount);
+    console.log("TRANSFER OUT", asset, amount);
+  }
+
+  function _collectFee(address asset, uint256 fromAmount) public returns (uint256) {
+    uint256 feeToTransfer = fromAmount.mul(fee).div(feeBase);
+    IERC20(asset).transferFrom(address(this), feeBeneficiaryAddress, feeToTransfer);
+    emit FeePaid(feeBeneficiaryAddress, feeToTransfer);
+    return fromAmount.sub(feeToTransfer);
+  }
+
+  // uses the same interface as default Exchange contract
+  function swapDaiForToken(
+    address asset,
+    uint256 amount,
+    uint256 receiveAtLeast,
+    address callee,
+    bytes calldata withData
+  ) public {
+    uint8 precision = precisions[asset];
+    amount = _collectFee(DAI_ADDRESS, amount);
+    uint256 amountOut = receiveAtLeast.mul(100).div(100-slippage);
+    _transferIn(msg.sender, DAI_ADDRESS, amount);
+    emit AssetSwap(DAI_ADDRESS, asset, amount, amountOut);
+    _transferOut(asset, msg.sender, amountOut);
+  }
+
+  // uses the same interface as default Exchange contract
+  function swapTokenForDai(
+    address asset,
+    uint256 amount,
+    uint256 receiveAtLeast,
+    address callee,
+    bytes calldata withData
+  ) public {
+    uint8 precision = precisions[asset];
+    uint256 amountOut = mul(mul(amount, 10**(18 - precision)), prices[asset]) / 10**18;
+    amountOut = _collectFee(DAI_ADDRESS, amountOut);
+
+    _transferIn(msg.sender, asset, amount);
+    emit AssetSwap(asset, DAI_ADDRESS, amount, amountOut);
+    _transferOut(DAI_ADDRESS, msg.sender, amountOut);
+  }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -119,6 +119,11 @@ module.exports = {
       accounts: [process.env.PRIV_KEY_MAINNET],
       gasPrice: 40000000000,
     },
+    goerli: {
+      url: process.env.ALCHEMY_NODE_GOERLI,
+      accounts: [process.env.PRIV_KEY_MAINNET],
+      gasPrice: 40000000000,
+    },
   },
   solidity: {
     version: '0.7.6',

--- a/scripts/goerli-deploy.js
+++ b/scripts/goerli-deploy.js
@@ -1,0 +1,43 @@
+const { ethers } = require('hardhat');
+/*
+In order to verify call
+npx hardhat verify >>address<< --network goerli
+npx hardhat verify  --constructor-args prod-exchange-params.js >>address<< --network goerli
+*/
+
+async function deploy() {
+  const provider = ethers.provider;
+  const signer = provider.getSigner(0);
+
+  console.log('Deployer address:',await signer.getAddress());
+  console.log('---Deploying the system---')
+
+  const MPActions = await ethers.getContractFactory('MultiplyProxyActions', signer)
+  console.log('---Deploying MultiplyProxyActions---')
+  const multiplyProxyActions = await MPActions.deploy()
+  let mpa =await multiplyProxyActions.deployed();
+  console.log('---MultiplyProxyActions Deployed---', mpa.address)
+
+  
+  const Exchange = await ethers.getContractFactory('GoerliDummyExchange', signer)
+  console.log('---Deploying Exchange---')
+  const exchange = await Exchange.deploy(
+    "0x59A5aC4033dB403587e8BEAb8996EDe2F170413a",
+    20,
+    80,
+    "0x11fe4b6ae13d2a6055c8d9cf65c55bac32b5d844",
+    mpa.address
+  )
+  const exchangeInstance = await exchange.deployed();
+  console.log('---Exchange Deployed---', exchangeInstance.address)
+
+
+  console.log('---System successfully deployed!---')
+}
+
+deploy()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/goerli-exchange-params.js
+++ b/scripts/goerli-exchange-params.js
@@ -1,0 +1,7 @@
+module.exports = [
+    "0x59A5aC4033dB403587e8BEAb8996EDe2F170413a",
+    20,
+    80,
+    "0x11fe4b6ae13d2a6055c8d9cf65c55bac32b5d844",
+    
+  ];

--- a/scripts/goerli-exchange-params.js
+++ b/scripts/goerli-exchange-params.js
@@ -3,5 +3,5 @@ module.exports = [
     20,
     80,
     "0x11fe4b6ae13d2a6055c8d9cf65c55bac32b5d844",
-    
+    "0x62fab0FfcC439c75a7d31F94f5B34bE31F3e08E7"
   ];

--- a/scripts/production-deploy.js
+++ b/scripts/production-deploy.js
@@ -21,6 +21,7 @@ async function deploy() {
   let mpa =await multiplyProxyActions.deployed();
   console.log('---MultiplyProxyActions Deployed---', mpa.address)
 
+  
   const Exchange = await ethers.getContractFactory('Exchange', signer)
   console.log('---Deploying Exchange---')
   const exchange = await Exchange.deploy(

--- a/scripts/production-deploy.js
+++ b/scripts/production-deploy.js
@@ -10,7 +10,7 @@ async function deploy() {
   const signer = provider.getSigner(0);
   const authCaller = process.env.AUTH_CALLER;
   const feeRecipient = process.env.FEE_RECIPIENT;
-  const FEE = 20;
+  const FEE = 0;
 
   console.log('Deployer address:',await signer.getAddress());
   console.log('---Deploying the system---')

--- a/scripts/production-deploy.js
+++ b/scripts/production-deploy.js
@@ -10,11 +10,11 @@ async function deploy() {
   const signer = provider.getSigner(0);
   const authCaller = process.env.AUTH_CALLER;
   const feeRecipient = process.env.FEE_RECIPIENT;
-  const FEE = 0;
+  const FEE = 20;
 
   console.log('Deployer address:',await signer.getAddress());
   console.log('---Deploying the system---')
-  
+
   const MPActions = await ethers.getContractFactory('MultiplyProxyActions', signer)
   console.log('---Deploying MultiplyProxyActions---')
   const multiplyProxyActions = await MPActions.deploy()

--- a/scripts/production-deploy.js
+++ b/scripts/production-deploy.js
@@ -14,7 +14,14 @@ async function deploy() {
 
   console.log('Deployer address:',await signer.getAddress());
   console.log('---Deploying the system---')
+  
+  const MPActions = await ethers.getContractFactory('MultiplyProxyActions', signer)
+  console.log('---Deploying MultiplyProxyActions---')
+  const multiplyProxyActions = await MPActions.deploy()
+  let mpa =await multiplyProxyActions.deployed();
+  console.log('---MultiplyProxyActions Deployed---', mpa.address)
 
+  const Exchange = await ethers.getContractFactory('Exchange', signer)
   console.log('---Deploying Exchange---')
   const exchange = await Exchange.deploy(
     authCaller,

--- a/scripts/production-deploy.js
+++ b/scripts/production-deploy.js
@@ -15,13 +15,6 @@ async function deploy() {
   console.log('Deployer address:',await signer.getAddress());
   console.log('---Deploying the system---')
 
-  const MPActions = await ethers.getContractFactory('MultiplyProxyActions', signer)
-  console.log('---Deploying MultiplyProxyActions---')
-  const multiplyProxyActions = await MPActions.deploy()
-  let mpa =await multiplyProxyActions.deployed();
-  console.log('---MultiplyProxyActions Deployed---', mpa.address)
-  
-  const Exchange = await ethers.getContractFactory('Exchange', signer)
   console.log('---Deploying Exchange---')
   const exchange = await Exchange.deploy(
     authCaller,

--- a/test/common/mcd-deployment-utils.js
+++ b/test/common/mcd-deployment-utils.js
@@ -285,7 +285,9 @@ const loadDummyExchangeFixtures = async function (provider, signer, dummyExchang
       if (debug) {
         console.log(`${token.name} precision: ${token.precision}`)
       }
-      return dummyExchangeInstance.setPrecision(token.address, token.precision)
+      if(dummyExchangeInstance.setPrecision)
+        return dummyExchangeInstance.setPrecision(token.address, token.precision)
+      else return true;
     }),
   )
 
@@ -299,7 +301,10 @@ const loadDummyExchangeFixtures = async function (provider, signer, dummyExchang
         if (debug) {
           console.log(`${token.name} Price: ${price.toString()} and Price(wei): ${priceInWei}`)
         }
-        return dummyExchangeInstance.setPrice(token.address, priceInWei)
+        if(dummyExchangeInstance.setPrice)
+          return dummyExchangeInstance.setPrice(token.address, priceInWei)
+        else return true;
+        
       }),
   )
 

--- a/test/goerli-exchange-tests.js
+++ b/test/goerli-exchange-tests.js
@@ -1,0 +1,393 @@
+const {
+  balanceOf,
+  MAINNET_ADRESSES,
+  FEE,
+  FEE_BASE,
+  init,
+  loadDummyExchangeFixtures,
+  ONE,
+  swapTokens,
+} = require('./common/mcd-deployment-utils')
+const { expect } = require('chai')
+const {
+  amountFromWei,
+  amountToWei,
+  convertToBigNumber,
+} = require('./common/params-calculation-utils')
+const { exchangeToDAI, exchangeFromDAI } = require('./common/http_apis')
+const wethAbi = require('../abi/IWETH.json')
+const erc20Abi = require('../abi/IERC20.json')
+const BigNumber = require('bignumber.js')
+const { zero } = require('./utils')
+const _ = require('lodash')
+
+const AGGREGATOR_V3_ADDRESS = '0x11111112542d85b3ef69ae05771c2dccff4faa26'
+
+const ethers = hre.ethers
+const ALLOWED_PROTOCOLS = ['UNISWAP_V2']
+
+function asPercentageValue(value, base) {
+  value = convertToBigNumber(value)
+
+  return {
+    get value() {
+      return value
+    },
+
+    asDecimal: value.div(new BigNumber(base)),
+  }
+}
+
+describe('Exchange', async function () {
+  let provider, signer, address, exchange, WETH, DAI, feeBeneficiary, slippage, fee, snapshotId;
+
+  this.beforeAll(async function () {
+    console.log("Before init");
+    let [_provider, _signer] = await init(undefined, provider, signer)
+    console.log("After init");
+    provider = _provider
+    signer = _signer
+    address = await signer.getAddress()
+    
+    feeBeneficiary = await ( await _provider.getSigner(1)).getAddress();
+    slippage = asPercentageValue(8, 100)
+    fee = asPercentageValue(FEE, FEE_BASE)
+
+    console.log("Fee and slippage", FEE, 8);
+
+    const GoerliDummyExchange = await ethers.getContractFactory('GoerliDummyExchange', signer)
+    exchange = await GoerliDummyExchange.deploy(feeBeneficiary, FEE, 8, MAINNET_ADRESSES.MCD_DAI, address)
+    await exchange.deployed()
+    
+    await loadDummyExchangeFixtures(provider, signer, exchange, true);
+    console.log("After deploy", address);
+
+    WETH = new ethers.Contract(MAINNET_ADRESSES.ETH, wethAbi, provider).connect(signer)
+    DAI = new ethers.Contract(MAINNET_ADRESSES.MCD_DAI, erc20Abi, provider).connect(signer)
+  })
+
+  this.beforeEach(async function () {
+    snapshotId = await provider.send('evm_snapshot', [])
+  })
+
+  this.afterEach(async function () {
+    await provider.send('evm_revert', [snapshotId])
+  })
+
+  it('should have fee set', async function () {
+    const exchangeFee = await exchange.fee()
+    expect(exchangeFee.toString()).to.be.eq(fee.value.toString())
+  })
+
+  it('should have fee beneficiary address set', async function () {
+    const exchangeFeeBeneficiary = await exchange.feeBeneficiaryAddress()
+    expect(exchangeFeeBeneficiary).to.be.eq(feeBeneficiary)
+  })
+
+  it('should have a whitelisted caller set', async function () {
+    expect(await exchange.WHITELISTED_CALLERS(address)).to.be.true
+  })
+
+  describe('Asset for DAI', async function () {
+    const amount = new BigNumber(10)
+    const amountInWei = amountToWei(amount).toFixed(0)
+    let receiveAtLeastInWei
+    let to, data
+
+    this.beforeAll(async function () {
+      const response = await exchangeToDAI(
+        MAINNET_ADRESSES.ETH,
+        amountInWei,
+        exchange.address,
+        slippage.value.toString(),
+        ALLOWED_PROTOCOLS
+      )
+      initialDaiWalletBalance = convertToBigNumber(await balanceOf(MAINNET_ADRESSES.ETH, address))
+
+      const {
+        toTokenAmount,
+        tx: { to: _to, data: _data },
+      } = response
+      to = _to
+      data = _data
+
+      const receiveAtLeast = new BigNumber(amountFromWei(toTokenAmount)).times(
+        ONE.minus(slippage.asDecimal),
+      )
+      receiveAtLeastInWei = amountToWei(receiveAtLeast).toFixed(0)
+    })
+
+    this.afterEach(async function () {
+      await provider.send('evm_revert', [snapshotId])
+    })
+
+    it('should not happen if it is triggered from unauthorized caller', async () => {
+      let tx = exchange
+        .connect(provider.getSigner(1))
+        .swapTokenForDai(
+          MAINNET_ADRESSES.ETH,
+          amountToWei(1).toFixed(0),
+          amountFromWei(1).toFixed(0),
+          AGGREGATOR_V3_ADDRESS,
+          0,
+        )
+      await expect(tx).to.revertedWith('Exchange / Unauthorized Caller')
+    })
+
+    describe('when transferring an exact amount to the exchange', async function () {
+      let localSnapshotId, initialWethWalletBalance
+
+      this.beforeEach(async function () {
+        localSnapshotId = await provider.send('evm_snapshot', [])
+
+        let tx = await WETH.deposit({
+          value: amountToWei(amount.toNumber()).toFixed(0),
+        })
+
+        const intBal = await balanceOf( MAINNET_ADRESSES.ETH,address);
+
+        initialWethWalletBalance = convertToBigNumber(
+          intBal
+        )
+
+        await WETH.approve(exchange.address, amountInWei)
+
+        await exchange.swapTokenForDai(
+          MAINNET_ADRESSES.ETH,
+          amountInWei,
+          receiveAtLeastInWei,
+          to,
+          data,
+          {
+            value: 0,
+            gasLimit: 2500000,
+          },
+        )
+
+      })
+
+      this.afterEach(async function () {
+        await provider.send('evm_revert', [localSnapshotId])
+      })
+
+      it(`should receive at least amount specified in receiveAtLeast`, async function () {
+        const wethBalance = convertToBigNumber(await balanceOf(MAINNET_ADRESSES.ETH, address))
+        const daiBalance = convertToBigNumber(await balanceOf(MAINNET_ADRESSES.MCD_DAI, address))
+
+        expect(wethBalance.toString()).to.equals(
+          initialWethWalletBalance.minus(amountToWei(amount)).toString(),
+        )
+        expect(daiBalance.gte(convertToBigNumber(receiveAtLeastInWei))).to.be.true
+      })
+
+      it('should have collected fee', async function () {
+        const beneficiaryDaiBalance = convertToBigNumber(
+          await balanceOf(MAINNET_ADRESSES.MCD_DAI, feeBeneficiary),
+        )
+
+        const expectedCollectedFee = amountFromWei(receiveAtLeastInWei)
+          .div(ONE.minus(slippage.asDecimal))
+          .times(fee.asDecimal)
+
+        expect(amountFromWei(beneficiaryDaiBalance).toFixed(6)).to.be.eq(
+          expectedCollectedFee.toFixed(6),
+        )
+      })
+    })
+
+    describe('when transferring less amount to the exchange', async function () {
+      let initialWethWalletBalance, lessThanTheTransferAmount, localSnapshotId
+
+      this.beforeEach(async function () {
+        localSnapshotId = await provider.send('evm_snapshot', [])
+
+        await WETH.deposit({
+          value: amountToWei(1000).toFixed(0),
+        })
+
+        initialWethWalletBalance = convertToBigNumber(
+          await balanceOf(MAINNET_ADRESSES.ETH, address),
+        )
+        lessThanTheTransferAmount = convertToBigNumber(amountInWei).minus(5);
+
+        await WETH.approve(exchange.address, lessThanTheTransferAmount.toFixed(0))
+      })
+
+      this.afterEach(async function () {
+        await provider.send('evm_revert', [localSnapshotId])
+      })
+
+      it('should throw an error and not exchange anything', async function () {
+        let tx = exchange.swapTokenForDai(
+          MAINNET_ADRESSES.ETH,
+          amountInWei,
+          receiveAtLeastInWei,
+          to,
+          data,
+          {
+            value: 0,
+            gasLimit: 2500000,
+          },
+        )
+        await expect(tx).to.revertedWith("Exchange / Not enought allowance")
+
+        const wethBalance = convertToBigNumber(await balanceOf(MAINNET_ADRESSES.ETH, address))
+
+        expect(wethBalance.toString()).to.equals(initialWethWalletBalance.toString())
+      })
+    })
+
+  })
+
+  describe('DAI for Asset', async function () {
+    let initialDaiWalletBalance, amountWithFeeInWei
+
+    this.beforeAll(async function () {
+      const amountInWei = amountToWei(new BigNumber(1000))
+      amountWithFeeInWei = amountInWei.div(ONE.minus(fee.asDecimal)).toFixed(0)
+
+      const response = await exchangeFromDAI(
+        MAINNET_ADRESSES.ETH,
+        amountInWei.toFixed(0),
+        slippage.value.toString(),
+        exchange.address,
+        ALLOWED_PROTOCOLS
+      )
+
+      const {
+        toTokenAmount,
+        tx: { to: _to, data: _data },
+      } = response
+      to = _to
+      data = _data
+
+      const receiveAtLeast = new BigNumber(amountFromWei(toTokenAmount)).times(
+        ONE.minus(slippage.asDecimal),
+      )
+      receiveAtLeastInWei = amountToWei(receiveAtLeast).toFixed(0)
+    })
+
+    it('should not happen if it is triggered from unauthorized caller', async () => {
+      let tx = exchange
+        .connect(provider.getSigner(1))
+        .swapDaiForToken(
+          MAINNET_ADRESSES.ETH,
+          amountToWei(1).toFixed(0),
+          amountFromWei(1).toFixed(0),
+          AGGREGATOR_V3_ADDRESS,
+          0,
+        )
+
+      await expect(tx).to.revertedWith('Exchange / Unauthorized Caller')
+    })
+
+    describe('when transferring an exact amount to the exchange', async function () {
+      let localSnapshotId
+
+      this.beforeEach(async function () {
+        localSnapshotId = await provider.send('evm_snapshot', [])
+
+        await swapTokens(
+          MAINNET_ADRESSES.ETH,
+          MAINNET_ADRESSES.MCD_DAI,
+          amountToWei(new BigNumber(10), 18).toFixed(0),
+          amountWithFeeInWei,
+          address,
+          provider,
+          signer,
+        )
+
+        initialDaiWalletBalance = convertToBigNumber(
+          await balanceOf(MAINNET_ADRESSES.MCD_DAI, address),
+        )
+
+        await DAI.approve(exchange.address, amountWithFeeInWei)
+
+        await exchange.swapDaiForToken(
+          MAINNET_ADRESSES.ETH,
+          amountWithFeeInWei,
+          receiveAtLeastInWei,
+          to,
+          data,
+          {
+            value: 0,
+            gasLimit: 2500000,
+          },
+        )
+      })
+
+      this.afterEach(async function () {
+        await provider.send('evm_revert', [localSnapshotId])
+      })
+
+      it(`should receive at least amount specified in receiveAtLeast`, async function () {
+        const wethBalance = convertToBigNumber(await balanceOf(MAINNET_ADRESSES.ETH, address))
+        const daiBalance = convertToBigNumber(await balanceOf(MAINNET_ADRESSES.MCD_DAI, address))
+
+        expect(daiBalance.toString()).to.be.equal(
+          initialDaiWalletBalance.minus(amountWithFeeInWei).toString(),
+        )
+        expect(wethBalance.gte(convertToBigNumber(receiveAtLeastInWei))).to.be.true
+      })
+
+      it('should have collected fee', async function () {
+        const beneficiaryDaiBalance = convertToBigNumber(
+          await balanceOf(MAINNET_ADRESSES.MCD_DAI, feeBeneficiary),
+        )
+
+        const expectedCollectedFee = convertToBigNumber(amountWithFeeInWei).times(fee.asDecimal)
+        expect(beneficiaryDaiBalance.toFixed(0)).to.be.eq(expectedCollectedFee.toFixed(0))
+      })
+    })
+
+    describe('when transferring less amount to the exchange', async function () {
+      let lessThanTheTransferAmount, localSnapshotId, deficitAmount
+
+      this.beforeEach(async function () {
+        localSnapshotId = await provider.send('evm_snapshot', [])
+
+        await swapTokens(
+          MAINNET_ADRESSES.ETH,
+          MAINNET_ADRESSES.MCD_DAI,
+          amountToWei(new BigNumber(10), 18).toFixed(0),
+          amountWithFeeInWei,
+          address,
+          provider,
+          signer,
+        )
+
+        initialDaiWalletBalance = convertToBigNumber(
+          await balanceOf(MAINNET_ADRESSES.MCD_DAI, address),
+        )
+        deficitAmount = new BigNumber(10)
+        lessThanTheTransferAmount = convertToBigNumber(amountWithFeeInWei)
+          .minus(deficitAmount)
+          .toFixed(0)
+
+        await DAI.approve(exchange.address, lessThanTheTransferAmount)
+      })
+
+      this.afterEach(async function () {
+        await provider.send('evm_revert', [localSnapshotId])
+      })
+
+      it('should throw an error and not exchange anything', async function () {
+        let tx = exchange.swapDaiForToken(
+          MAINNET_ADRESSES.ETH,
+          amountWithFeeInWei,
+          receiveAtLeastInWei,
+          to,
+          data,
+          {
+            value: 0,
+            gasLimit: 2500000,
+          },
+        )
+        await expect(tx).to.be.revertedWith("Exchange / Not enought allowance")
+        
+      })
+    })
+
+  })
+
+})


### PR DESCRIPTION
In order to run tests first
`npx hardhat node`

then (in other terminal)

`npx hardhat test test\goerli-exchange-tests.js --network local`


[Story](https://app.shortcut.com/oazo-apps/story/3198/create-another-type-of-dummyexchange)

