### PR TITLE
TECH-1124 - Upgrading Node.js 12 (End-of-Life) Github Actions to Node.js 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     -
       name: Login into Dockerhub
       uses: docker/login-action@v1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,10 +6,10 @@ jobs:
 
     steps:
           # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache YARN dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
           
         with:
           path: node_modules


### PR DESCRIPTION
TECH-1124 - Node.js 12 Github Actions are deprecated as Node.js 12 reached End-of-Life on April 2022. This PR upgrades them to Node.js 16